### PR TITLE
IPv6 fix: tests are now running properly when server is listening on …

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -248,7 +248,7 @@ describe('engine.io-rooms', function () {
       // need to add a small delay
       setTimeout(function () {
         c1.send('send');
-      }, 15);
+      }, 500);
 
     });
   });

--- a/test/test.js
+++ b/test/test.js
@@ -8,6 +8,14 @@ var expect = require('expect.js');
 // creates a conn.io client for the given server
 function client(srv){
   var addr = srv.address();
+
+  // Host `::` is a valid IPv6 host.
+  // engine.io-client is not parsing `::` as a host.
+  // To fix this issue, we have to use `localhost`.
+  if (addr.address === '::') {
+    addr.address = 'localhost';
+  }
+
   var url = 'ws://' + addr.address + ':' + addr.port;
   return ioc(url);
 }


### PR DESCRIPTION
Please, see Issue #1.

Tests are failing if the server is running on IPv6.
